### PR TITLE
Fix typos in staff handler texts

### DIFF
--- a/src/tg2go/bot/handlers/staff/callbacks/category_action/add.py
+++ b/src/tg2go/bot/handlers/staff/callbacks/category_action/add.py
@@ -42,7 +42,7 @@ async def CommandStaffAddCategoryIndex(
     if not message.text.isdigit():
         await SendMessage(
             chat_id=message.chat.id,
-            text="Индекс обязян быть целым положительным числом",
+            text="Индекс обязан быть целым положительным числом",
             context=ContextIO.UserFailed,
         )
         return

--- a/src/tg2go/bot/handlers/staff/callbacks/category_action/change.py
+++ b/src/tg2go/bot/handlers/staff/callbacks/category_action/change.py
@@ -119,7 +119,7 @@ async def CategoryChangeIndexChange(
 
     await SendMessage(
         chat_id=message.chat.id,
-        text="✅ Индекс категории успешно измененен",
+        text="✅ Индекс категории успешно изменен",
     )
 
     menu = await CategoryChangeMenu(data["category_id"])

--- a/src/tg2go/bot/handlers/staff/callbacks/good_action/add.py
+++ b/src/tg2go/bot/handlers/staff/callbacks/good_action/add.py
@@ -63,7 +63,7 @@ async def CommandStaffAddGoodPriceRub(
 
     await SendMessage(
         chat_id=message.chat.id,
-        text="Укажите описание продукта, добавляя ингридиенты и граммовки.",
+        text="Укажите описание продукта, добавляя ингредиенты и граммовки.",
     )
 
     await state.set_state(AddGoodStates.Description)

--- a/src/tg2go/bot/handlers/staff/callbacks/good_action/change.py
+++ b/src/tg2go/bot/handlers/staff/callbacks/good_action/change.py
@@ -98,7 +98,7 @@ async def GoodChangePriceRub(
 
     await SendMessage(
         chat_id=callback_query.message.chat.id,
-        text="Напишите новою цену позиции",
+        text="Напишите новую цену позиции",
     )
 
     await state.set_state(GoodChangePriceRubStates.Change)

--- a/src/tg2go/bot/handlers/staff/callbacks/good_action/remove.py
+++ b/src/tg2go/bot/handlers/staff/callbacks/good_action/remove.py
@@ -15,7 +15,7 @@ router = Router()
 @router.callback_query(
     GoodRemoveCallbackData.filter(F.action == GoodRemoveAction.Delete)
 )
-async def CategoryRemoveDelete(
+async def GoodRemoveDelete(
     callback_query: types.CallbackQuery,
     callback_data: GoodRemoveCallbackData,
 ) -> None:
@@ -29,7 +29,7 @@ async def CategoryRemoveDelete(
 
     await SendMessage(
         chat_id=callback_query.message.chat.id,
-        text="Категория успешно удалена",
+        text="Позиция успешно удалена",
     )
 
     good = await srv.GetGood(callback_data.good_id)
@@ -45,7 +45,7 @@ async def CategoryRemoveDelete(
 
 
 @router.callback_query(GoodRemoveCallbackData.filter(F.action == GoodRemoveAction.Back))
-async def CategoryRemoveBack(
+async def GoodRemoveBack(
     callback_query: types.CallbackQuery,
     callback_data: GoodRemoveCallbackData,
 ) -> None:


### PR DESCRIPTION
## Summary
- correct spelling mistakes in Russian messages
- show accurate removal message for a menu item
- fix misnamed delete/back callbacks for goods

## Testing
- `ruff check src/tg2go/bot/handlers/staff`
- `mypy src/tg2go/bot/handlers/staff` *(fails: Module "sqlalchemy.ext.asyncio" etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685989b8b0508330a529a01c7e68fb6d